### PR TITLE
Use BYN for Belarus

### DIFF
--- a/src/data/currency.ts
+++ b/src/data/currency.ts
@@ -24,7 +24,7 @@ export const countryCurrency = {
   BR: "BRL",
   BS: "BSD",
   JE: "GBP",
-  BY: "BYR",
+  BY: "BYN",
   BZ: "BZD",
   RU: "RUB",
   RW: "RWF",


### PR DESCRIPTION
In 2016 Belarus changed from BYR to BYN
https://en.wikipedia.org/wiki/Belarusian_ruble